### PR TITLE
fix issue #17 - prompt backgound is black with transparent theme

### DIFF
--- a/lua/neoai/ui.lua
+++ b/lua/neoai/ui.lua
@@ -22,6 +22,26 @@ M.clear_input = function()
 	end
 end
 
+M.get_component_heights = function (output_height_percentage)
+  local lines_height = vim.api.nvim_get_option("lines")
+  local statusline_height = vim.o.laststatus == 0 and 0 or 1 -- height of the statusline if present
+  local cmdline_height = vim.o.cmdheight -- height of the cmdline if present
+  local tabline_height = vim.o.showtabline == 0 and 0 or 1 -- height of the tabline if present
+  local total_height = lines_height
+  local used_height = statusline_height + cmdline_height + tabline_height
+  local layout_height = total_height - used_height
+  local output_height = math.floor(layout_height * output_height_percentage / 100)
+  local prompt_height = layout_height - output_height
+  local starting_row = tabline_height == 0 and 0 or 1
+
+  return {
+    starting_row = starting_row,
+    layout = layout_height,
+    output = output_height,
+    prompt = prompt_height,
+  }
+end
+
 M.is_focused = function()
 	if M.input_popup == nil then
 		vim.notify("NeoAI GUI needs to be open", vim.log.levels.ERROR)
@@ -102,23 +122,22 @@ M.create_ui = function()
 		},
 	})
 
-	local output_height = config.options.ui.output_popup_height
-
+  local component_heights = M.get_component_heights(config.options.ui.output_popup_height)
 	M.layout = Layout(
 		{
 			relative = "editor",
 			position = {
-				row = "0%",
+				row = component_heights.starting_row,
 				col = "100%",
 			},
 			size = {
 				width = config.options.ui.width .. "%",
-				height = "100%",
+				height = component_heights.layout,
 			},
 		},
 		Layout.Box({
-			Layout.Box(M.output_popup, { size = output_height .. "%" }),
-			Layout.Box(M.input_popup, { size = (100 - output_height) .. "%" }),
+			Layout.Box(M.output_popup, { size = component_heights.output }),
+			Layout.Box(M.input_popup, { size = component_heights.prompt }),
 		}, { dir = "col" })
 	)
 	M.layout:mount()

--- a/lua/neoai/ui.lua
+++ b/lua/neoai/ui.lua
@@ -96,7 +96,7 @@ M.create_ui = function()
 			readonly = false,
 		},
 		win_options = {
-			winblend = 10,
+			winblend = 0,
 			winhighlight = "Normal:Normal,FloatBorder:FloatBorder",
 			wrap = true,
 		},


### PR DESCRIPTION
whitout fixes
![20230417_18h27m38s_grim](https://user-images.githubusercontent.com/61181/232648262-8aad43e9-cc87-4c29-af69-0105f8d21ac2.png)
fixed prompt background (winblend=0) but still an issue with statusline 
![20230417_19h25m05s_grim](https://user-images.githubusercontent.com/61181/232648756-3a2ca501-c967-4768-8298-73b0981018bf.png)
fixed for status line without tabline and without cmdline
![20230417_19h41m08s_grim](https://user-images.githubusercontent.com/61181/232648325-ecbe4b23-ee31-428e-a802-1a6b7d354496.png)
fixed for status line and cmdheight=2 without tabline
![20230417_19h41m58s_grim](https://user-images.githubusercontent.com/61181/232648340-cc7206fc-9431-46ed-bfa8-f72963041f38.png)
fixed for empty editor
![20230417_19h43m06s_grim](https://user-images.githubusercontent.com/61181/232648380-a3d6a095-100c-4ef9-a73e-9cf421e894c8.png)
fixed for statusline and tabline enabled
![20230417_19h44m10s_grim](https://user-images.githubusercontent.com/61181/232648382-47b81d59-e3c8-4842-851e-2b92d5ab6444.png)
