### PR TITLE
Configurable "submit" keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ being inside your editor.
 ![Normal Mode GUI](./gifs/normal_mode.gif)
 
 In the Prompt Buffer, you can send text by pressing Enter while in insert mode.
-Additionally, you can insert a newline by using Control Enter.
+Additionally, you can insert a newline by using Control Enter. This mapping
+can be changed in the config.
 
 Also note that the plugin has a feature where the output from the model
 automatically gets saved to the `g` register and all code snippets get saved to
@@ -157,6 +158,7 @@ require('neoai').setup{
         input_popup_text = "Prompt",
         width = 30,      -- As percentage eg. 30%
         output_popup_height = 80, -- As percentage eg. 80%
+        submit = "<Enter>", -- Key binding to submit the prompt
     },
     models = {
         {
@@ -225,6 +227,7 @@ available options are as follows:
  - `input_popup_text`: Header text shown on the input popup window (default: "Prompt").
  - `width`: Width of the window as a percentage (e.g., 30 = 30%, default: 30).
  - `output_popup_height`: Height of the output popup as a percentage (e.g., 80 = 80%, default: 80).
+ - `submit`: Key binding to submit the prompt. If set to <Enter>, <C-Enter> will be mapped to insert a newline. (default: "<Enter>").
 
 ### Model Options
  - `models`: A list of models to use:

--- a/lua/neoai/config.lua
+++ b/lua/neoai/config.lua
@@ -9,6 +9,7 @@ M.get_defaults = function()
             input_popup_text = "Prompt",
             width = 30,               -- As percentage eg. 30%
             output_popup_height = 80, -- As percentage eg. 80%
+            submit = "<Enter>",
         },
         models = {
             {
@@ -72,6 +73,7 @@ end
 ---@field input_popup_text string Header text shown on input popup window
 ---@field width integer The width of the window as a percentage number 30 = 30%
 ---@field output_popup_height integer The height of the output popup as a percentage
+---@field submit string The key binding to submit the input
 
 ---@class Model_Options
 ---@field name "openai" The name of the model provider

--- a/lua/neoai/ui.lua
+++ b/lua/neoai/ui.lua
@@ -161,8 +161,10 @@ M.create_ui = function()
 	end
 
 	local opts = { noremap = true, silent = true }
-	vim.api.nvim_buf_set_keymap(input_buffer, "i", "<C-Enter>", "<Enter>", opts)
-	vim.api.nvim_buf_set_keymap(input_buffer, "i", "<Enter>", "<cmd>lua require('neoai.ui').submit_prompt()<cr>", opts)
+	if string.lower(config.options.ui.submit) == "<enter>" then
+		vim.api.nvim_buf_set_keymap(input_buffer, "i", "<C-Enter>", "<Enter>", opts)
+	end
+	vim.api.nvim_buf_set_keymap(input_buffer, "i", config.options.ui.submit, "<cmd>lua require('neoai.ui').submit_prompt()<cr>", opts)
 end
 
 M.send_prompt = function(prompt)


### PR DESCRIPTION
I wanted to reverse the key bindings so `<Enter>` would be normal and `<C-Enter>` would submit the prompt. This change:

- Adds a setup option `submit` under `ui` for the submit binding, default `<Enter>` (current behavior)
- If that option is set to `<Enter>`, map `<C-Enter>` to `<Enter>` (current behavior)
- If it's anything else, just create the submit binding and leave `<Enter>` alone
- Also updates the documentation accordingly.