### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ For packer:
 use ({
     "Bryley/neoai.nvim",
     requires = { "MunifTanjim/nui.nvim" },
+    config = function()
+        require("neoai").setup({
+            -- Options go here
+        })
+    end,
 })
 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For packer:
 ```lua
 use ({
     "Bryley/neoai.nvim",
-    require = { "MunifTanjim/nui.nvim" },
+    requires = { "MunifTanjim/nui.nvim" },
 })
 
 


### PR DESCRIPTION
The key for packer dependencies is `requires`, not `require`.

https://github.com/wbthomason/packer.nvim/blob/master/doc/packer.txt#L323-L339

Also, the config function is needed for packer, otherwise `config.options` doesn't get initialized correctly and the user will get an error the first time one of its values is referenced.