### PR TITLE
Add OpenAI URL Api

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,9 @@ end
 ### OpenAI API Key
  - `open_api_key_env`: The environment variable that contains the OpenAI API key (default: "OPENAI_API_KEY").
 
+### OpenAI API Url
+- `open_api_url`: The openai api url (default: "https://api.openai.com/v1/chat/completions")
+
 
 ### Mappings
  - `mappings`: A table containing the following actions that can be keys:

--- a/lua/neoai/chat/models/openai.lua
+++ b/lua/neoai/chat/models/openai.lua
@@ -66,7 +66,7 @@ M.send_to_model = function(chat_history, on_stdout_chunk, on_complete)
         "--silent",
         "--show-error",
         "--no-buffer",
-        "https://api.openai.com/v1/chat/completions",
+		config.options.open_api_url,
         "-H",
         "Content-Type: application/json",
         "-H",

--- a/lua/neoai/config.lua
+++ b/lua/neoai/config.lua
@@ -40,6 +40,7 @@ M.get_defaults = function()
             ["select_down"] = "<C-j>",
         },
         open_api_key_env = "OPENAI_API_KEY",
+        open_api_url = "https://api.openai.com/v1/chat/completions",
         shortcuts = {
             {
                 name = "textify",
@@ -108,6 +109,7 @@ end
 ---@field inject Inject_Options The inject options
 ---@field prompts Prompt_Options The custom prompt options
 ---@field open_api_key_env string The environment variable that contains the openai api key
+---@field open_api_url string The openai api url
 ---@field mappings table<"select_up" | "select_down", nil|string|string[]> A table of actions with it's mapping(s)
 ---@field shortcuts Shortcut[] Array of shortcuts
 M.options = {}


### PR DESCRIPTION
FIx:  change the api.openai.com URL within the config
Added openai_api_url in the configuration file.
#20 