### PR TITLE
docs: fix missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ require('neoai').setup{
     models = {
         {
             name = "openai",
-            model = "gpt-3.5-turbo"
+            model = "gpt-3.5-turbo",
             params = nil,
         },
     },


### PR DESCRIPTION
Adds a missing trailing comma in the example config.