### PR TITLE
feat: "Implement Optional Base URL Configuration for OpenAI Server"

### DIFF
--- a/lua/neoai/chat/models/openai.lua
+++ b/lua/neoai/chat/models/openai.lua
@@ -53,6 +53,7 @@ end
 ---@param on_complete fun(err?: string, output?: string) Function to call when model has finished
 M.send_to_model = function(chat_history, on_stdout_chunk, on_complete)
     local api_key = config.options.open_ai.api_key.get()
+    local base_url = config.options.open_ai.base_url.get()
 
     local data = {
         model = chat_history.model,
@@ -67,7 +68,7 @@ M.send_to_model = function(chat_history, on_stdout_chunk, on_complete)
         "--silent",
         "--show-error",
         "--no-buffer",
-        "https://api.openai.com/v1/chat/completions",
+        base_url .. "/chat/completions",
         "-H",
         "Content-Type: application/json",
         "-H",

--- a/lua/neoai/config.lua
+++ b/lua/neoai/config.lua
@@ -72,6 +72,33 @@ M.get_defaults = function()
                     error(msg)
                 end,
             },
+            base_url = {
+                env = "OPENAI_BASE_URL",
+                value = nil,
+                get = function()
+                    local base_url = nil
+                    if M.options.open_ai.base_url.value then
+                        base_url = M.options.open_ai.base_url.value
+                    else
+                        local env_name
+                        if M.options.base_url_env then
+                            env_name = M.options.base_url_env
+                            logger.deprecation("config.base_url_env", "config.open_ai.base_url.env")
+                        else
+                            env_name = M.options.open_ai.base_url.env
+                        end
+                        base_url = os.getenv(env_name)
+                    end
+
+                    if base_url then
+                        return base_url
+                    end
+                    local msg = M.options.open_ai.base_url.env
+                        .. " environment variable is not set, and base_url.value is empty"
+                    logger.error(msg)
+                    error(msg)
+                end,
+            }
         },
         shortcuts = {
             {
@@ -135,11 +162,17 @@ end
 
 ---@class Open_AI_Options
 ---@field api_key Open_AI_Key_Options The open api key options
+---@field base_url Open_AI_Key_Options The open api key options
 
 ---@class Open_AI_Key_Options
 ---@field env string The environment variable to get the open api key from
 ---@field value string | nil The value of the open api key to use, if nil then use the environment variable
 ---@field get fun(): string The function to get the open api key
+
+---@class Open_Base_Url_Options
+---@field env string The environment variable to get the open base url from
+---@field value string | nil The value of the open base url to use, if nil then use the environment variable
+---@field get fun(): string The function to get the open base url
 
 ---@class Options
 ---@field ui UI_Options UI configurations


### PR DESCRIPTION
- Add a new option `base_url` in the config for the OpenAI server's base URL
- Replace the hardcoded URL for API calls to OpenAI with the new `base_url` config option
- Retrieve the `base_url` from environment variable or value directly from config
- Update classes documentation comments to include `base_url` option details