### PR TITLE
fix: API key lookup to use env field instead of `get()`

### DIFF
--- a/lua/neoai/chat/models/openai.lua
+++ b/lua/neoai/chat/models/openai.lua
@@ -52,7 +52,7 @@ end
 ---@param on_stdout_chunk fun(chunk: string) Function to call whenever a stdout chunk occurs
 ---@param on_complete fun(err?: string, output?: string) Function to call when model has finished
 M.send_to_model = function (chat_history, on_stdout_chunk, on_complete)
-    local api_key = os.getenv(config.options.open_ai.api_key.get())
+    local api_key = os.getenv(config.options.open_ai.api_key.env)
     if not api_key then
       on_complete("OpenAI API Key is missing.", nil)
       return


### PR DESCRIPTION
### What’s Changed
In `lua/neoai/chat/models/openai.lua`, the API‑key lookup in `M.send_to_model` was updated to use the configured **environment‑variable name** (`api_key.env`) instead of its **value** (`api_key.get()`).

```diff
 M.send_to_model = function (…)
-  local api_key = os.getenv(config.options.open_ai.api_key.get())
+  local api_key = os.getenv(config.options.open_ai.api_key.env)
   if not api_key then
     on_complete("OpenAI API Key is missing.", nil)
     return
   end
   …
 end

Could you review this?
